### PR TITLE
Don't send current time as ts to every API call

### DIFF
--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -7,8 +7,6 @@ class SlackRequest(object):
         pass
 
     def do(self, token, request="?", post_data={}, domain="slack.com"):
-        t = time.time()
-        post_data["ts"] = t
         post_data["token"] = token
         post_data = urllib.urlencode(post_data)
         url = 'https://{}/api/{}'.format(domain, request)


### PR DESCRIPTION
When debugging an issue for a customer I realized that we send `ts` parameter on every call to the API, set to `time.time()`. Unfortunately some of our API methods (e.g. [chat.update](https://api.slack.com/methods/chat.update)) use a `ts` argument, so were impossible to call.

This pull request fixes that issue. But, I don't know all of the details of this code so I may have missed a reason for sending this argument? I couldn't find anything in commit history!