### PR TITLE
If the provided channel name contains a # character, remove it.

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -33,6 +33,7 @@ class SlackClient(object):
             raise SlackNotConnected
 
     def rtm_send_message(self, channel, message):
+        channel = channel.replace('#', '')
         return self.server.channels.find(channel).send_message(message)
 
 class SlackNotConnected(Exception):

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -18,7 +18,7 @@ class SlackClient(object):
             return False
 
     def api_call(self, method, **kwargs):
-        return self.server.api_call(method, kwargs)
+        return self.server.api_call(method, **kwargs)
 
     def rtm_read(self):
         #in the future, this should handle some events internally i.e. channel creation


### PR DESCRIPTION
If the user provides a channel name containing the # character, remove it. I naturally attempted to input #<channel> when first using this project as I usually reference channel names with # when communicating both verbally and typing.

Also addresses an issue with SlackClient.api_call