### PR TITLE
Fix connected property, add lstrip('#')

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -36,7 +36,7 @@ class SlackClient(object):
             raise SlackNotConnected
 
     def rtm_send_message(self, channel, message):
-        return self.server.channels.find(channel).send_message(message)
+        return self.server.channels.find(channel.lstrip('#')).send_message(message)
 
     def process_changes(self, data):
         if "type" in data.keys():

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -49,6 +49,7 @@ class Server(object):
                 if not reconnect:
                     self.parse_slack_login_data(login_data)
                 self.connect_slack_websocket(self.ws_url)
+                self.connected = True
             else:
                 raise SlackLoginError
 


### PR DESCRIPTION
Ok, so issues experienced in #21 are due to a couple of misleading details which are easily fixed:

- _sc.server has a connected property, but it is never set to true. Setting it to True after connecting the web socket fixes this and allows checking for already connected sockets in long lived processes.

- send_message expects the channel name to be given without the leading ‘#’, but it is common to mistype this. Stripping any leading ‘#” from the channel name in send_message fixes this.