### PR TITLE
Detect disconnected websocket connections

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -2,6 +2,7 @@ from slackclient._slackrequest import SlackRequest
 from slackclient._channel import Channel
 from slackclient._user import User
 from slackclient._util import SearchList
+from ssl import SSLWantReadError
 
 from websocket import create_connection
 import json
@@ -106,8 +107,9 @@ class Server(object):
         while True:
             try:
                 data += "{}\n".format(self.websocket.recv())
-            except:
-                return data.rstrip()
+            except SSLWantReadError:
+                return ''
+            return data.rstrip()
 
     def attach_user(self, name, id, real_name, tz):
         self.users.append(User(self, name, id, real_name, tz))


### PR DESCRIPTION
With the current implementation, a disconnected websocket is not
detected as *all* exceptions are silently swallowed, resulting in
`rtm_read()` returning an empty list forever without raising any
kind of exception.

This makes it impossible to detect that the websocket has been
disconnected and keeps client libraries reading forever while never
receiving data anymore.

With these changes, a `socket.error` (python 2) or `TimeoutError` (python 3)
will be thrown when the socket
gets disconnected (and other exceptions should bubble up as well) so
that users of this library know they must re-connect.