### PR TITLE
Re-introduce support for Python < 2.7.9

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -2,7 +2,7 @@ from slackclient._slackrequest import SlackRequest
 from slackclient._channel import Channel
 from slackclient._user import User
 from slackclient._util import SearchList
-from ssl import SSLWantReadError
+from ssl import SSLError
 
 from websocket import create_connection
 import json
@@ -107,8 +107,16 @@ class Server(object):
         while True:
             try:
                 data += "{}\n".format(self.websocket.recv())
-            except SSLWantReadError:
-                return ''
+            except SSLError as e:
+                if e.errno == 2:
+                    # errno 2 occurs when trying to read or write data, but more
+                    # data needs to be received on the underlying TCP transport
+                    # before the request can be fulfilled.
+                    #
+                    # Python 2.7.9+ and Python 3.3+ give this its own exception,
+                    # SSLWantReadError
+                    return ''
+                raise
             return data.rstrip()
 
     def attach_user(self, name, id, real_name, tz):


### PR DESCRIPTION
42bfde0082f5c26bc94b94f62fcffcbcc14969b2 introduced a change that relied on an Exception class ([ssl.SSLWantReadError]()) present only in modern Python versions. This changes that to work exactly the same way, only in a way that works for older Python versions also.

Fixes #29.