### PR TITLE
Added Channel.get_history for fetching messages per the channel/groups.history api.

### DIFF
--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -24,3 +24,12 @@ class Channel(object):
         message_json = {"type": "message", "channel": self.id, "text": message}
         self.server.send_to_websocket(message_json)
 
+    def get_history(self,latest=None,oldest=None,inclusive=None,count=None):
+        arguments = {"channel": self.id}
+        if latest: arguments["latest"] = latest
+        if oldest: arguments["oldest"] = oldest
+        if inclusive: arguments["inclusive"] = inclusive
+        if count: arguments["count"] = count
+        api = "channels.history" if self.id[0] != "G" else "groups.history"
+        return self.server.api_call(api, post_data=arguments)
+    

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -10,9 +10,9 @@ class SlackClient(object):
         self.token = token
         self.server = Server(self.token, False)
 
-    def rtm_connect(self):
+    def rtm_connect(self, reconnect=False):
         try:
-            self.server.rtm_connect()
+            self.server.rtm_connect(reconnect)
             return True
         except:
             return False

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -130,13 +130,16 @@ class Server(object):
                                     "channels.join?name={}".format(name)).read())
 
     def api_call(self, method, **kwargs):
-        reply = self.api_requester.do(self.token, method, kwargs)
-        return reply.read()
-
+        reply = self.api_requester.do(self.token, method, **kwargs)
+        if reply.code != 200:
+            raise SlackApiError
+        return json.loads(reply.read().decode("utf-8"))
 
 class SlackConnectionError(Exception):
     pass
 
-
 class SlackLoginError(Exception):
+    pass
+
+class SlackApiError(Exception):
     pass


### PR DESCRIPTION
This was needed for a project that I am working on. Note that the `Server.api_call` has also been modified to fix a bug with calling `Request.do` without unwinding `kwargs` into the call. Also added a little error handling and returning.

Also slipped a `reconnect` option into the the `Client` side...

Quick question: what is the logic behind having both "Client" and "Server" classes? Why not just Client without all the proxying?