### PR TITLE
Fix duplicate channels and users issue.

### DIFF
--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -120,10 +120,12 @@ class Server(object):
             return data.rstrip()
 
     def attach_user(self, name, id, real_name, tz):
-        self.users.append(User(self, name, id, real_name, tz))
+        if self.users.find(id) is None:
+            self.users.append(User(self, name, id, real_name, tz))
 
     def attach_channel(self, name, id, members=[]):
-        self.channels.append(Channel(self, name, id, members))
+        if self.channels.find(id) is None:
+            self.channels.append(Channel(self, name, id, members))
 
     def join_channel(self, name):
         print(self.api_requester.do(self.token,


### PR DESCRIPTION
Occasionally, there will be duplicate channels in the `client.server.channels` instance. User lists will also be duplicated when this happens.

This is likely caused by reconnection issues or resent messages from the Slack API, but the end result is that message sending will crash when sending to channels that are duplicated:

    File "/root/botty-bot-bot-bot/src/bot.py", line 79, in say
        self.client.rtm_send_message(channel_id, sendable_text)
    File "/usr/local/lib/python3.4/dist-packages/slackclient/_client.py", line 39, in rtm_send_message
        return self.server.channels.find(channel).send_message(message)
    AttributeError: 'list' object has no attribute 'send_message'

This patch fixes the issue by preventing duplicated channels from occurring.