### PR TITLE
Add users to local cache in server when they join the team

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -46,6 +46,9 @@ class SlackClient(object):
             if data["type"] == 'im_created':
                 channel = data["channel"]
                 self.server.attach_channel(channel["user"], channel["id"], [])
+            if data["type"] == "team_join":
+                user = data["user"]
+                self.server.parse_user_data([user])
             pass
 
 


### PR DESCRIPTION
A small change to handle "team_join" events in the same way "channel_created" and "im_created" events are handled, keeping the servers list of users updated.