### PR TITLE
Fixing urllib py2/3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(name='slackclient',
       packages=['slackclient'],
       install_requires=[
         'websocket-client',
+        'future',
       ],
       zip_safe=False)

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -1,13 +1,7 @@
 import time
-
-try:
-    # Try for Python3
-    from urllib.parse import urlencode 
-    from urllib.request import urlopen 
-except:
-    # Looks like Python2
-    from urllib import urlencode 
-    from urllib2 import urlopen 
+from future.moves.urllib.parse import urlparse, urlencode
+from future.moves.urllib.request import urlopen, Request
+from future.moves.urllib.error import HTTPError
 
 
 class SlackRequest(object):


### PR DESCRIPTION
This addresses a bug I was running into in python2 while my environment has the `six` and `future` packages installed.

Here's the stack trace I was getting prior to this fix.

Note that this PR adds a dependency on the `future` package.

```
  File "/home/maxime_beauchemin/airflow/airflow/operators/slack_operator.py", line 50, in execute
    sc.api_call(self.method, **self.params)
  File "/home/maxime_beauchemin/code/python-slackclient/slackclient/_client.py", line 21, in api_call
    return self.server.api_call(method, **kwargs)
  File "/home/maxime_beauchemin/code/python-slackclient/slackclient/_server.py", line 133, in api_call
    reply = self.api_requester.do(self.token, method, kwargs)
  File "/home/maxime_beauchemin/code/python-slackclient/slackclient/_slackrequest.py", line 17, in do
    return urlopen(url, post_data.encode('utf-8'))
  File "/home/maxime_beauchemin/airflow/env/local/lib/python2.7/site-packages/future-0.15.2-py2.7.egg/future/backports/urllib/request.py", line 171, in urlopen
    return opener.open(url, data, timeout)
  File "/home/maxime_beauchemin/airflow/env/local/lib/python2.7/site-packages/future-0.15.2-py2.7.egg/future/backports/urllib/request.py", line 494, in open
    response = self._open(req, data)
  File "/home/maxime_beauchemin/airflow/env/local/lib/python2.7/site-packages/future-0.15.2-py2.7.egg/future/backports/urllib/request.py", line 517, in _open
    'unknown_open', req)
  File "/home/maxime_beauchemin/airflow/env/local/lib/python2.7/site-packages/future-0.15.2-py2.7.egg/future/backports/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/home/maxime_beauchemin/airflow/env/local/lib/python2.7/site-packages/future-0.15.2-py2.7.egg/future/backports/urllib/request.py", line 1353, in unknown_open
    raise URLError('unknown url type: %s' % type)
URLError: <urlopen error unknown url type: https>
root: ERROR: <urlopen error unknown url type: https>
```