### PR TITLE
Adding support for private groups and multi-person direct messages

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -40,7 +40,7 @@ class SlackClient(object):
 
     def process_changes(self, data):
         if "type" in data.keys():
-            if data["type"] == 'channel_created':
+            if data["type"] in ('channel_created', 'group_joined'):
                 channel = data["channel"]
                 self.server.attach_channel(channel["name"], channel["id"], [])
             if data["type"] == 'im_created':


### PR DESCRIPTION
This fixes the issue that newly joined/created private groups and multi-person direct messages are not recognized until the bot is restarted as documented in #55 and slackhq/python-rtmbot#24
