### PR TITLE
[CLEANUP] Resolve PEP8 errors and misc improvements

### DIFF
--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -3,15 +3,18 @@ from slackclient._channel import Channel
 from slackclient._server import Server
 from slackclient._client import SlackClient
 
+
 @pytest.fixture
 def server(monkeypatch):
     myserver = Server('xoxp-1234123412341234-12341234-1234', False)
     return myserver
 
+
 @pytest.fixture
 def slackclient(server):
     myslackclient = SlackClient('xoxp-1234123412341234-12341234-1234')
     return myslackclient
+
 
 @pytest.fixture
 def channel(server):

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -6,18 +6,18 @@ from slackclient._client import SlackClient
 
 @pytest.fixture
 def server(monkeypatch):
-    myserver = Server('xoxp-1234123412341234-12341234-1234', False)
-    return myserver
+    my_server = Server('xoxp-1234123412341234-12341234-1234', False)
+    return my_server
 
 
 @pytest.fixture
 def slackclient(client_server):
-    myslackclient = SlackClient('xoxp-1234123412341234-12341234-1234')
-    return myslackclient
+    my_slackclient = SlackClient('xoxp-1234123412341234-12341234-1234')
+    return my_slackclient
 
 
 @pytest.fixture
 def channel(channel_server):
-    mychannel = Channel(channel_server, "somechannel", "C12341234", ["user"])
-    return mychannel
+    my_channel = Channel(channel_server, "somechannel", "C12341234", ["user"])
+    return my_channel
 

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -11,13 +11,13 @@ def server(monkeypatch):
 
 
 @pytest.fixture
-def slackclient(server):
+def slackclient(client_server):
     myslackclient = SlackClient('xoxp-1234123412341234-12341234-1234')
     return myslackclient
 
 
 @pytest.fixture
-def channel(server):
-    mychannel = Channel(server, "somechannel", "C12341234", ["user"])
+def channel(channel_server):
+    mychannel = Channel(channel_server, "somechannel", "C12341234", ["user"])
     return mychannel
 

--- a/_pytest/test_channel.py
+++ b/_pytest/test_channel.py
@@ -1,8 +1,10 @@
 from slackclient._channel import Channel
 import pytest
 
+
 def test_Channel(channel):
     assert type(channel) == Channel
+
 
 @pytest.mark.xfail
 def test_Channel_send_message(channel):

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -7,22 +7,22 @@ import pytest
 
 @pytest.fixture
 def login_data():
-    login_data = open('_pytest/data/rtm.start.json', 'r').read()
-    login_data = json.loads(login_data)
-    return login_data
+    file_login_data = open('_pytest/data/rtm.start.json', 'r').read()
+    json_login_data = json.loads(file_login_data)
+    return json_login_data
 
 
 def test_Server(server):
     assert type(server) == Server
 
 
-def test_Server_parse_channel_data(server, login_data):
-    server.parse_channel_data(login_data["channels"])
+def test_Server_parse_channel_data(server, user_login_data):
+    server.parse_channel_data(user_login_data["channels"])
     assert type(server.channels.find('general')) == Channel
 
 
-def test_Server_parse_user_data(server, login_data):
-    server.parse_user_data(login_data["users"])
+def test_Server_parse_user_data(server, user_login_data):
+    server.parse_user_data(user_login_data["users"])
     assert type(server.users.find('fakeuser')) == User
 
 

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -4,11 +4,13 @@ from slackclient._channel import Channel
 import json
 import pytest
 
+
 @pytest.fixture
 def login_data():
     login_data = open('_pytest/data/rtm.start.json','r').read()
     login_data = json.loads(login_data)
     return login_data
+
 
 def test_Server(server):
     assert type(server) == Server
@@ -18,13 +20,16 @@ def test_Server_parse_channel_data(server, login_data):
     server.parse_channel_data(login_data["channels"])
     assert type(server.channels.find('general')) == Channel
 
+
 def test_Server_parse_user_data(server, login_data):
     server.parse_user_data(login_data["users"])
     assert type(server.users.find('fakeuser')) == User
 
+
 def test_Server_cantconnect(server):
     with pytest.raises(SlackLoginError):
         reply = server.ping()
+
 
 @pytest.mark.xfail
 def test_Server_ping(server, monkeypatch):

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.fixture
 def login_data():
-    login_data = open('_pytest/data/rtm.start.json','r').read()
+    login_data = open('_pytest/data/rtm.start.json', 'r').read()
     login_data = json.loads(login_data)
     return login_data
 

--- a/_pytest/test_server.py
+++ b/_pytest/test_server.py
@@ -33,6 +33,6 @@ def test_Server_cantconnect(server):
 
 @pytest.mark.xfail
 def test_Server_ping(server, monkeypatch):
-    #monkeypatch.setattr("", lambda: True)
+    # monkeypatch.setattr("", lambda: True)
     monkeypatch.setattr("websocket.create_connection", lambda: True)
     reply = server.ping()

--- a/_pytest/test_slackclient.py
+++ b/_pytest/test_slackclient.py
@@ -3,11 +3,13 @@ from slackclient._channel import Channel
 import json
 import pytest
 
+
 @pytest.fixture
 def channel_created():
     channel_created = open('_pytest/data/channel.created.json', 'r').read()
     channel_created = json.loads(channel_created)
     return channel_created
+
 
 @pytest.fixture
 def im_created():
@@ -15,8 +17,10 @@ def im_created():
     channel_created = json.loads(channel_created)
     return channel_created
 
+
 def test_SlackClient(slackclient):
     assert type(slackclient) == SlackClient
+
 
 def test_SlackClient_process_changes(slackclient, channel_created, im_created):
     slackclient.process_changes(channel_created)

--- a/_pytest/test_slackclient.py
+++ b/_pytest/test_slackclient.py
@@ -6,25 +6,25 @@ import pytest
 
 @pytest.fixture
 def channel_created():
-    channel_created = open('_pytest/data/channel.created.json', 'r').read()
-    channel_created = json.loads(channel_created)
-    return channel_created
+    file_channel_created_data = open('_pytest/data/channel.created.json', 'r').read()
+    json_channel_created_data = json.loads(file_channel_created_data)
+    return json_channel_created_data
 
 
 @pytest.fixture
 def im_created():
-    channel_created = open('_pytest/data/im.created.json', 'r').read()
-    channel_created = json.loads(channel_created)
-    return channel_created
+    file_channel_created_data = open('_pytest/data/im.created.json', 'r').read()
+    json_channel_created_data = json.loads(file_channel_created_data)
+    return json_channel_created_data
 
 
 def test_SlackClient(slackclient):
     assert type(slackclient) == SlackClient
 
 
-def test_SlackClient_process_changes(slackclient, channel_created, im_created):
-    slackclient.process_changes(channel_created)
+def test_SlackClient_process_changes(slackclient, channel_created_data, im_created_data):
+    slackclient.process_changes(channel_created_data)
     assert type(slackclient.server.channels.find('fun')) == Channel
-    slackclient.process_changes(im_created)
+    slackclient.process_changes(im_created_data)
     assert type(slackclient.server.channels.find('U123BL234')) == Channel
 

--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -23,4 +23,3 @@ class Channel(object):
     def send_message(self, message):
         message_json = {"type": "message", "channel": self.id, "text": message}
         self.server.send_to_websocket(message_json)
-

--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -1,9 +1,9 @@
 class Channel(object):
-    def __init__(self, server, name, channel_id, members=[]):
+    def __init__(self, server, name, channel_id, members=None):
         self.server = server
         self.name = name
         self.id = channel_id
-        self.members = members
+        self.members = [] if members is None else members
 
     def __eq__(self, compare_str):
         if self.name == compare_str or self.name == "#" + compare_str or self.id == compare_str:

--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -1,8 +1,8 @@
 class Channel(object):
-    def __init__(self, server, name, id, members=[]):
+    def __init__(self, server, name, channel_id, members=[]):
         self.server = server
         self.name = name
-        self.id = id
+        self.id = channel_id
         self.members = members
 
     def __eq__(self, compare_str):

--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -5,6 +5,7 @@ import json
 
 from slackclient._server import Server
 
+
 class SlackClient(object):
     def __init__(self, token):
         self.token = token

--- a/slackclient/_im.py
+++ b/slackclient/_im.py
@@ -23,4 +23,3 @@ class Im(object):
     def send_message(self, message):
         message_json = {"type": "message", "channel": self.id, "text": message}
         self.server.send_to_websocket(message_json)
-

--- a/slackclient/_im.py
+++ b/slackclient/_im.py
@@ -1,8 +1,8 @@
 class Im(object):
-    def __init__(self, server, user, id):
+    def __init__(self, server, user, im_id):
         self.server = server
         self.user = user
-        self.id = id
+        self.id = im_id
 
     def __eq__(self, compare_str):
         if self.id == compare_str or self.user == compare_str:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -123,7 +123,9 @@ class Server(object):
         if self.users.find(channel_id) is None:
             self.users.append(User(self, name, channel_id, real_name, tz))
 
-    def attach_channel(self, name, channel_id, members=[]):
+    def attach_channel(self, name, channel_id, members=None):
+        if members is None:
+            members = []
         if self.channels.find(channel_id) is None:
             self.channels.append(Channel(self, name, channel_id, members))
 

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -19,6 +19,7 @@ class Server(object):
         self.channels = SearchList()
         self.connected = False
         self.pingcounter = 0
+        self.ws_url = None
         self.api_requester = SlackRequest()
 
         if connect:

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -119,13 +119,13 @@ class Server(object):
                 raise
             return data.rstrip()
 
-    def attach_user(self, name, id, real_name, tz):
-        if self.users.find(id) is None:
-            self.users.append(User(self, name, id, real_name, tz))
+    def attach_user(self, name, channel_id, real_name, tz):
+        if self.users.find(channel_id) is None:
+            self.users.append(User(self, name, channel_id, real_name, tz))
 
-    def attach_channel(self, name, id, members=[]):
-        if self.channels.find(id) is None:
-            self.channels.append(Channel(self, name, id, members))
+    def attach_channel(self, name, channel_id, members=[]):
+        if self.channels.find(channel_id) is None:
+            self.channels.append(Channel(self, name, channel_id, members))
 
     def join_channel(self, name):
         print(self.api_requester.do(self.token,

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -1,7 +1,5 @@
-import time
-from future.moves.urllib.parse import urlparse, urlencode
-from future.moves.urllib.request import urlopen, Request
-from future.moves.urllib.error import HTTPError
+from future.moves.urllib.parse import urlencode
+from future.moves.urllib.request import urlopen
 
 
 class SlackRequest(object):

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -14,4 +14,3 @@ class SlackRequest(object):
         post_data = urlencode(post_data)
         url = 'https://{}/api/{}'.format(domain, request)
         return urlopen(url, post_data.encode('utf-8'))
-

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -6,7 +6,8 @@ class SlackRequest(object):
     def __init__(self):
         pass
 
-    def do(self, token, request="?", post_data=None, domain="slack.com"):
+    @staticmethod
+    def do(token, request="?", post_data=None, domain="slack.com"):
         if post_data is None:
             post_data = {}
         post_data["token"] = token

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -8,7 +8,9 @@ class SlackRequest(object):
     def __init__(self):
         pass
 
-    def do(self, token, request="?", post_data={}, domain="slack.com"):
+    def do(self, token, request="?", post_data=None, domain="slack.com"):
+        if post_data is None:
+            post_data = {}
         post_data["token"] = token
         post_data = urlencode(post_data)
         url = 'https://{}/api/{}'.format(domain, request)

--- a/slackclient/_user.py
+++ b/slackclient/_user.py
@@ -1,10 +1,10 @@
 class User(object):
-    def __init__(self, server, name, id, real_name, tz):
+    def __init__(self, server, name, user_id, real_name, tz):
         self.tz = tz
         self.name = name
         self.real_name = real_name
         self.server = server
-        self.id = id
+        self.id = user_id
 
     def __eq__(self, compare_str):
         if self.id == compare_str or self.name == compare_str:

--- a/slackclient/_util.py
+++ b/slackclient/_util.py
@@ -11,6 +11,7 @@ class SearchList(list):
 
         if len(items) == 1:
             return items[0]
-        elif items != []:
+        elif items:
             return items
-
+        else:
+            return None


### PR DESCRIPTION
## Overview

This PR resolves a number of PEP8 errors and makes a few miscellaneous improvements. 

**Note**: No functionality was added or removed, but there is a bugfix to make default arguments immutable.

## Details

- Fixes PEP8 whitespacing
- Changes variables names that shadow outer scope
- Adds an explicit return value to `_util.find`
- Remove unused imports
- Make `SlackRequest.do method static`
- Define instance variable `ws_url` in `Server.__init__`