### PR TITLE
parse json response into a dict before returning

### DIFF
--- a/slackclient/_client.py
+++ b/slackclient/_client.py
@@ -19,7 +19,7 @@ class SlackClient(object):
             return False
 
     def api_call(self, method, **kwargs):
-        return self.server.api_call(method, **kwargs)
+        return json.loads(self.server.api_call(method, **kwargs))
 
     def rtm_read(self):
         # in the future, this should handle some events internally i.e. channel


### PR DESCRIPTION
One of two solutions to issue #47. I prefer this one, because even though it breaks existing apps, it's now consistent with rtm_read() returning dicts.