### PR TITLE
Fix channel comparison with # prefix

### DIFF
--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -6,7 +6,7 @@ class Channel(object):
         self.members = [] if members is None else members
 
     def __eq__(self, compare_str):
-        if self.name == compare_str or self.name == "#" + compare_str or self.id == compare_str:
+        if self.name == compare_str or "#" + self.name == compare_str or self.id == compare_str:
             return True
         else:
             return False


### PR DESCRIPTION
The equality comparison for Channel objects has a typo.  When pulled from the server, channel names don't have a hash symbol. So the hash symbol should be prefixed to `self.name`, not the comparison string.  This should make calls like `sc.server.channels.find("#general")` work as expected.