### PR TITLE
Add support for nested structure, e.g. attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ print sc.api_call("api.test")
 print sc.api_call("channels.info", channel="1234567890")
 print sc.api_call(
     "chat.postMessage", channel="#general", text="Hello from Python! :tada:",
-    username='pybot', icon_emoji=':robot_face:'
+    username='pybot', icon_emoji=':robot_face:',
+    attachments=[{'title': 'This is an attachment', 'color': 'good'}]
 )
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ ipdb==0.9.3
 ipython==4.1.2
 pdbpp==0.8.3
 pytest>=2.8.2
+pytest-mock>=1.1
 pytest-cov==2.2.1
 pytest-pythonpath>=0.3
 testfixtures==4.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 future==0.15.2
+six==1.10.0
 websocket-client==0.35.0

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(name='slackclient',
       install_requires=[
         'websocket-client',
         'requests',
+        'six',
       ],
       zip_safe=False)

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -16,5 +16,6 @@ class SlackRequest(object):
 
         url = 'https://{0}/api/{1}'.format(domain, request)
         post_data['token'] = token
+        files = {'file': post_data.pop('file')} if 'file' in post_data else None
 
-        return requests.post(url, data=post_data)
+        return requests.post(url, data=post_data, files=files)

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -1,5 +1,7 @@
 import json
+
 import requests
+import six
 
 
 class SlackRequest(object):
@@ -8,8 +10,8 @@ class SlackRequest(object):
     def do(token, request="?", post_data=None, domain="slack.com"):
         post_data = post_data or {}
 
-        for k, v in post_data.items():
-            if not isinstance(v, (str, unicode)):
+        for k, v in six.iteritems(post_data):
+            if not isinstance(v, six.string_types):
                 post_data[k] = json.dumps(v)
 
         url = 'https://{0}/api/{1}'.format(domain, request)

--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -1,3 +1,4 @@
+import json
 import requests
 
 
@@ -6,7 +7,12 @@ class SlackRequest(object):
     @staticmethod
     def do(token, request="?", post_data=None, domain="slack.com"):
         post_data = post_data or {}
-        return requests.post(
-            'https://{0}/api/{1}'.format(domain, request),
-            data=dict(post_data, token=token),
-        )
+
+        for k, v in post_data.items():
+            if not isinstance(v, (str, unicode)):
+                post_data[k] = json.dumps(v)
+
+        url = 'https://{0}/api/{1}'.format(domain, request)
+        post_data['token'] = token
+
+        return requests.post(url, data=post_data)

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -1,0 +1,17 @@
+from slackclient._slackrequest import SlackRequest
+import json
+
+
+def test_post_attachements(mocker):
+    requests = mocker.patch('slackclient._slackrequest.requests')
+
+    SlackRequest.do('xoxb-123',
+                    'chat.postMessage',
+                    {'attachments': [{'title': 'hello'}]})
+
+    assert requests.post.call_count == 1
+    args, kwargs = requests.post.call_args
+    assert 'https://slack.com/api/chat.postMessage' == args[0]
+    assert {'attachments': json.dumps([{'title': 'hello'}]),
+            'token': 'xoxb-123'} == kwargs['data']
+    assert None == kwargs['files']


### PR DESCRIPTION
> The optional attachments argument should contain a JSON-encoded array of attachments.
>
> https://api.slack.com/methods/chat.postMessage

This enables simpler calls like this:

```python
sc.api_call('chat.postMessage', {'attachments': [{'title': 'hello'}]})
# instead of
sc.api_call('chat.postMessage', {'attachments': json.dumps([{'title': 'hello'}]}))
```