### PR TITLE
make objects python3 compatible

### DIFF
--- a/slackclient/_channel.py
+++ b/slackclient/_channel.py
@@ -11,6 +11,9 @@ class Channel(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __str__(self):
         data = ""
         for key in list(self.__dict__.keys()):

--- a/slackclient/_im.py
+++ b/slackclient/_im.py
@@ -10,6 +10,9 @@ class Im(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __str__(self):
         data = ""
         for key in list(self.__dict__.keys()):

--- a/slackclient/_server.py
+++ b/slackclient/_server.py
@@ -31,6 +31,9 @@ class Server(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.token)
+
     def __str__(self):
         data = ""
         for key in list(self.__dict__.keys()):

--- a/slackclient/_user.py
+++ b/slackclient/_user.py
@@ -12,6 +12,9 @@ class User(object):
         else:
             return False
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __str__(self):
         data = ""
         for key in list(self.__dict__.keys()):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -16,6 +16,16 @@ def test_channel_eq(channel):
     assert channel == 'C12345678'
     assert (channel == 'foo') is False
 
+def test_channel_hash(channel):
+    channel = Channel(
+        'test-server',
+        'test-channel',
+        'C12345678',
+    )
+    channel_map = {channel: channel.id}
+    assert channel_map[channel] == 'C12345678'
+    assert (channel_map[channel] == 'foo') is False
+
 @pytest.mark.xfail
 def test_channel_send_message(channel):
     channel.send_message('hi')

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -16,7 +16,7 @@ def test_channel_eq(channel):
     assert channel == 'C12345678'
     assert (channel == 'foo') is False
 
-def test_channel_hash(channel):
+def test_channel_is_hashable(channel):
     channel = Channel(
         'test-server',
         'test-channel',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,12 @@ def test_Server(server):
     assert type(server) == Server
 
 
+def test_Server_hash(server):
+    server_map = {server: server.token}
+    assert server_map[server] == 'xoxp-1234123412341234-12341234-1234'
+    assert (server_map[server] == 'foo') is False
+
+
 def test_Server_parse_channel_data(server, login_fixture):
     server.parse_channel_data(login_fixture["channels"])
     assert type(server.channels.find('general')) == Channel

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,7 +16,7 @@ def test_Server(server):
     assert type(server) == Server
 
 
-def test_Server_hash(server):
+def test_Server_is_hashable(server):
     server_map = {server: server.token}
     assert server_map[server] == 'xoxp-1234123412341234-12341234-1234'
     assert (server_map[server] == 'foo') is False


### PR DESCRIPTION
In python 3, objects with `__eq__` methods need `__hash__` methods. Thus, here we write `__hash__` methods for the objects we have that were previously not hashable.