### PR TITLE
Fix bug: requests with a 'file' argument work now

### DIFF
--- a/slackclient/_slackrequest.py
+++ b/slackclient/_slackrequest.py
@@ -22,7 +22,12 @@ class SlackRequest(object):
         post_data = post_data or {}
 
         # Pull file out so it isn't JSON encoded like normal fields.
-        files = {'file': post_data.pop('file')} if 'file' in post_data else None
+        # Only do this for requests that are UPLOADING files; downloading files
+        # use the 'file' argument to point to a File ID.
+        upload_requests = ['files.upload']
+        files = None
+        if request in upload_requests:
+            files = {'file': post_data.pop('file')} if 'file' in post_data else None
 
         for k, v in six.iteritems(post_data):
             if not isinstance(v, six.string_types):

--- a/tests/test_slackrequest.py
+++ b/tests/test_slackrequest.py
@@ -17,6 +17,18 @@ def test_post_file(mocker):
             'token': 'xoxb-123'} == kwargs['data']
     assert None != kwargs['files']
 
+def test_get_file(mocker):
+    requests = mocker.patch('slackclient._slackrequest.requests')
+
+    SlackRequest.do('xoxb-123', 'files.info', {'file': 'myFavoriteFileID'})
+
+    assert requests.post.call_count == 1
+    args, kwargs = requests.post.call_args
+    assert 'https://slack.com/api/files.info' == args[0]
+    assert {'file': "myFavoriteFileID",
+            'token': 'xoxb-123'} == kwargs['data']
+    assert None == kwargs['files']
+
 def test_post_attachements(mocker):
     requests = mocker.patch('slackclient._slackrequest.requests')
 


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> e.g. Fix bug for requests with a 'file' argument. The current code assumes 'file' is always a file's content (upload), whereas there are many requests that take a fileID with the argument name 'file'.

#### Related Issues
> N/A (that I have found)

#### Test strategy
> e.g. Test files.info in addition to the files.upload test that already exists.