### PR TITLE
Fix contributing guideline link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* [ ] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing guidelines](./.github/CONTRIBUTING.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-* [ ] I've read and understood the [Contributing guidelines](python-slackclient/.github/CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](python-slackclient/CODE_OF_CONDUCT.md).
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 
 #### Description

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
-* [ ] I've read and understood the [Contributing guidelines](./.github/CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+* [ ] I've read and understood the [Contributing guidelines](python-slackclient/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](python-slackclient/CODE_OF_CONDUCT.md).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 
 #### Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-* [ ] I've read and understood the [Contributing guidelines](./.github/CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+* [ ] I've read and understood the [Contributing guidelines](python-slackclient/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](python-slackclient/CODE_OF_CONDUCT.md).
 * [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
-* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
+* [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
 * [ ] I've written tests to cover the new code and functionality included in this PR.
 * [ ] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-* [ ] I've read and understood the [Contributing guidelines](./CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing guidelines](./.github/CONTRIBUTING.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 * [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
 * [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-* [ ] I've read and understood the [Contributing guidelines](python-slackclient/.github/CONTRIBUTING.md) and have done my best effort to follow them.
-* [ ] I've read and agree to the [Code of Conduct](python-slackclient/CODE_OF_CONDUCT.md).
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
+* [ ] I've read and agree to the [Code of Conduct](https://github.com/slackhq/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
 * [ ] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
 * [ ] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
 * [ ] I've written tests to cover the new code and functionality included in this PR.


### PR DESCRIPTION
* [x] I've read and understood the [Contributing guidelines](https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://github.com/slackhq/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [x] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [x] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferrably).
* [x] I've written tests to cover the new code and functionality included in this PR.
* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary

This PR fixes the link in the issue and PR templates. Before they were based on relative urls but this would cause 404s when clicked in certain contexts. Moving to absolute urls the templates resolves this issue.

#### Related Issues

Fixes #121 

#### Test strategy

Manual verification