### PR TITLE
Add contribution guide and virtualenv set up in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,6 +118,8 @@ We ask that you include any appropriate tests or documentation in the pull reque
 `good commit message hygiene <https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25#.lsttwx97v>`_
 in your commit message and PR commentary.
 
+For more information, check out our `contribution guide <https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md>`_.
+
 Building Documentation
 -----------------------
 To build this documentation you'll need to create a virtual environment.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,27 +114,16 @@ Submitting a Pull Request
 -------------------------
 Please feel free to sent us pull requests or issues that you'd like to see included in the python-slackclient!
 
+Reviewing our `Contributing Guidelines <https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md>`_ and `Code of Conduct <https://github.com/slackhq/python-slackclient/blob/master/CODE_OF_CONDUCT.md>`_ before submitting your PR will make it easier for your contributions to be accepted. :D
+
 We ask that you include any appropriate tests or documentation in the pull request and try to follow
 `good commit message hygiene <https://medium.com/brigade-engineering/the-secrets-to-great-commit-messages-106fc0a92a25#.lsttwx97v>`_
 in your commit message and PR commentary.
 
-For more information, check out our `contribution guide <https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md>`_.
-
 Building Documentation
 -----------------------
-To build this documentation you'll need to create a virtual environment.
-You'll need to install `virtualenv <https://virtualenv.readthedocs.io/en/latest/>`_ if you don't already have it.
-
-.. code-block:: bash
-
-    pip install virtualenv
-
-After virtualenv is installed, create a new environment and activate it:
-
-.. code-block:: bash
-
-    virtualenv env
-    source env/bin/activate
+When building this documentation it's best practice to create a virtual environment.
+`Virtualenv <https://virtualenv.readthedocs.io/en/latest/>`_ is a good option.
 
 Now you're ready to install the dependencies and generate these docs for yourself!
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,7 +120,21 @@ in your commit message and PR commentary.
 
 Building Documentation
 -----------------------
-To build this documentation:
+To build this documentation you'll need to create a virtual environment.
+You'll need to install `virtualenv <https://virtualenv.readthedocs.io/en/latest/>`_ if you don't already have it.
+
+.. code-block:: bash
+
+    pip install virtualenv
+
+After virtualenv is installed, create a new environment and activate it:
+
+.. code-block:: bash
+
+    virtualenv env
+    source env/bin/activate
+
+Now you're ready to install the dependencies and generate these docs for yourself!
 
 .. code-block:: bash
 
@@ -136,4 +150,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
* [X] I've read and understood the [Contributing guidelines](https://github.com/slackhq/python-slackclient/blob/master/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://github.com/slackhq/python-slackclient/blob/master/CODE_OF_CONDUCT.md).
* [X] I've been mindful about doing atomic commits, adding documentation to my changes, not refactoring too much.
* [X] I've a descriptive title and added any useful information for the reviewer. Where appropriate, I've attached a screenshot and/or screencast (gif preferably).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://docs.google.com/a/slack-corp.com/forms/d/1q_w8rlJG_x_xJOoSUMNl7R35rkpA7N6pUkKhfHHMD9c/viewform).

#### PR Summary
> Included instructions on installing virtualenv, creating a new env and starting the env before building the docs to be more explicit.
> Added a link to the slack contribution guide in the contributions section of the documentation.

#### Related Issues
> None

#### Test strategy
> No tests needed
